### PR TITLE
Javascript interop section: Remove `:replicant/key` as it prevents panning and `flyTo` map effect

### DIFF
--- a/content/javascript-interop.md
+++ b/content/javascript-interop.md
@@ -414,8 +414,7 @@ hook:
 
 (defn render-map [data]
   [:div.aspect-video.mb-4
-   {:replicant/key data
-    :replicant/on-mount
+   {:replicant/on-mount
     (fn [{:replicant/keys [node remember]}]
       (remember (mount-map node data)))
 


### PR DESCRIPTION
In the tutorial for js-interop, this part keeps the `replicant/key` which prevents the nice smooth transition from `replicant/on-update` 
<img width="687" height="303" alt="image" src="https://github.com/user-attachments/assets/bf0e585b-23aa-433f-9faa-5406e6c6fd2f" />


This fixes the docs for people that follow along with the code 