### PR TITLE
Fix marker-map alias usage to avoid confusion with reagent component

### DIFF
--- a/content/interop-alias.md
+++ b/content/interop-alias.md
@@ -424,7 +424,7 @@ Using it looks like this:
     [:main.m-4
      (render-title name)
      (when position
-       [map/marker-map
+       [::map/marker-map
         {:class "mb-4" ;; <==
          ::map/center position
          ::map/zoom (or zoom 11)}

--- a/content/interop-alias.md
+++ b/content/interop-alias.md
@@ -376,7 +376,7 @@ we'll use hiccup-like nodes for the markers:
 ```clj
 (require '[atlas.ui.map :as map])
 
-[map/marker-map {::map/center position
+[::map/marker-map {::map/center position
                    ::map/zoom zoom}
  [::map/marker
   {:point/label "Pikachu"


### PR DESCRIPTION
[This](https://arc.net/l/quote/vknmzwjk) should be an alias in the docs: 

<img width="392" height="389" alt="image" src="https://github.com/user-attachments/assets/23256af7-4fac-4782-b179-9e2a85c9f03b" />
