### PR TITLE
Fixed function name in the tutorial Tic-Tac-Toe with aliases

### DIFF
--- a/content/tic-tac-toe-alias.md
+++ b/content/tic-tac-toe-alias.md
@@ -433,7 +433,7 @@ This is very similar to the test we just wrote, just with a different count:
 :block/markdown
 
 The main difference between the original implementation and the new one is the
-merging of `game->ui-data` and `render-data`. This change really pokes at the
+merging of `game->ui-data` and `render-board`. This change really pokes at the
 benefit and difficulty of using aliases well, because it both improved the
 implementation and blurred the lines a little.
 


### PR DESCRIPTION
The function render-data is never defined. The correct function is render-board.