### PR TITLE
Add interactive table of contents to articles

### DIFF
--- a/content/state-atom.md
+++ b/content/state-atom.md
@@ -216,6 +216,7 @@ based on the `^:nexus/batch` meta on the effect function.
 
 --------------------------------------------------------------------------------
 :block/title Beyond assoc-in
+:block/id beyond-assoc-in
 :block/level 2
 :block/markdown
 

--- a/resources/public/js/toc.js
+++ b/resources/public/js/toc.js
@@ -1,0 +1,105 @@
+(function () {
+
+  function initTableOfContents() {
+    var tocContainer = document.getElementById("table-of-contents-content");
+    if (!tocContainer) return;
+
+    // Get all heading elements that are referenced in the ToC
+    var tocLinks = tocContainer.querySelectorAll('a[href^="#"]');
+    if (tocLinks.length === 0) return;
+
+    var headings = [];
+    for (var i = 0; i < tocLinks.length; i++) {
+      var link = tocLinks[i];
+      var hash = link.getAttribute("href");
+      var id = hash.substring(1); // Remove the # from href
+
+      // Use getElementById instead of querySelector to handle special characters
+      var heading = document.getElementById(id);
+      if (heading) {
+        headings.push({
+          link: link,
+          element: heading,
+          id: id
+        });
+
+        // Add smooth scroll behavior to ToC links
+        link.addEventListener("click", function(e) {
+          e.preventDefault();
+
+          // Calculate the target position with padding
+          var elementTop = this.headingElement.getBoundingClientRect().top + window.pageYOffset;
+          var offsetTop = elementTop - 80; // 80px padding from top
+
+          window.scrollTo({
+            top: offsetTop,
+            behavior: "smooth"
+          });
+        }.bind({ headingElement: heading }));
+      }
+    }
+
+    if (headings.length === 0) return;
+
+    function updateActiveTocItem() {
+      var scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+      var windowHeight = window.innerHeight;
+
+      // Find the current active section
+      var activeIndex = -1;
+
+      for (var i = 0; i < headings.length; i++) {
+        var rect = headings[i].element.getBoundingClientRect();
+        var elementTop = rect.top + scrollTop;
+
+        // Consider a heading active if it's above the middle of the viewport
+        if (elementTop <= scrollTop + windowHeight / 3) {
+          activeIndex = i;
+        } else {
+          break;
+        }
+      }
+
+      // Update ToC link styles
+      for (var j = 0; j < headings.length; j++) {
+        var heading = headings[j];
+        var link = heading.link;
+        var isActive = j === activeIndex;
+
+        if (isActive) {
+          // Add active styles - text-primary color
+          link.classList.add("text-primary");
+        } else {
+          // Reset to default stylesheet
+          link.classList.remove("text-primary");
+        }
+      }
+    }
+
+    // Initial update
+    updateActiveTocItem();
+
+    // Update on scroll with throttling for better performance
+    var ticking = false;
+    function handleScroll() {
+      if (!ticking) {
+        requestAnimationFrame(function() {
+          updateActiveTocItem();
+          ticking = false;
+        });
+        ticking = true;
+      }
+    }
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+  }
+
+  // Initialize when DOM is ready
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", function () {
+      initTableOfContents();
+    });
+  } else {
+    initTableOfContents();
+  }
+})();

--- a/resources/public/js/toc.js
+++ b/resources/public/js/toc.js
@@ -8,6 +8,7 @@
     var tocLinks = tocContainer.querySelectorAll('a[href^="#"]');
     if (tocLinks.length === 0) return;
 
+    var allArticleHeadings = Array.from(document.querySelectorAll('h2, h3'))
     var headings = [];
     for (var i = 0; i < tocLinks.length; i++) {
       var link = tocLinks[i];
@@ -15,7 +16,10 @@
       var id = hash.substring(1); // Remove the # from href
 
       // Use getElementById instead of querySelector to handle special characters
-      var heading = document.getElementById(id);
+      var heading = document.getElementById(id) ||
+                    // try to find element by text (non-blocks content doens't have normalized ids)
+                    allArticleHeadings.filter(h => h.textContent.trim() === link.textContent.trim())[0]
+
       if (heading) {
         headings.push({
           link: link,

--- a/resources/public/js/toc.js
+++ b/resources/public/js/toc.js
@@ -1,5 +1,4 @@
 (function () {
-
   function initTableOfContents() {
     var tocContainer = document.getElementById("table-of-contents-content");
     if (!tocContainer) return;
@@ -8,7 +7,7 @@
     var tocLinks = tocContainer.querySelectorAll('a[href^="#"]');
     if (tocLinks.length === 0) return;
 
-    var allArticleHeadings = Array.from(document.querySelectorAll('h2, h3'))
+    var allArticleHeadings = Array.from(document.querySelectorAll("h2, h3"));
     var headings = [];
     for (var i = 0; i < tocLinks.length; i++) {
       var link = tocLinks[i];
@@ -16,30 +15,38 @@
       var id = hash.substring(1); // Remove the # from href
 
       // Use getElementById instead of querySelector to handle special characters
-      var heading = document.getElementById(id) ||
-                    // try to find element by text (non-blocks content doens't have normalized ids)
-                    allArticleHeadings.filter(h => h.textContent.trim() === link.textContent.trim())[0]
+      var heading =
+          document.getElementById(id) ||
+            // try to find element by text (full markdown pages don't have normalized ids)
+            allArticleHeadings.filter(
+              (h) => h.textContent.trim() === link.textContent.trim(),
+            )[0];
 
       if (heading) {
         headings.push({
           link: link,
           element: heading,
-          id: id
+          id: id,
         });
 
         // Add smooth scroll behavior to ToC links
-        link.addEventListener("click", function(e) {
-          e.preventDefault();
+        link.addEventListener(
+          "click",
+          function (e) {
+            e.preventDefault();
 
-          // Calculate the target position with padding
-          var elementTop = this.headingElement.getBoundingClientRect().top + window.pageYOffset;
-          var offsetTop = elementTop - 80; // 80px padding from top
+            // Calculate the target position with padding
+            var elementTop =
+                this.headingElement.getBoundingClientRect().top +
+                  window.pageYOffset;
+            var offsetTop = elementTop - 80; // 80px padding from top
 
-          window.scrollTo({
-            top: offsetTop,
-            behavior: "smooth"
-          });
-        }.bind({ headingElement: heading }));
+            window.scrollTo({
+              top: offsetTop,
+              behavior: "smooth",
+            });
+          }.bind({ headingElement: heading }),
+        );
       }
     }
 
@@ -87,7 +94,7 @@
     var ticking = false;
     function handleScroll() {
       if (!ticking) {
-        requestAnimationFrame(function() {
+        requestAnimationFrame(function () {
           updateActiveTocItem();
           ticking = false;
         });

--- a/src/repliweb/article.clj
+++ b/src/repliweb/article.clj
@@ -127,7 +127,7 @@
       [:span "On this page"]]
      [:ul#table-of-contents-content
       (for [{:keys [id text depth]} toc-entries]
-        [:li.relative {:data-depth depth}
+        [:li {:data-depth depth}
          [:a {:href (str "#" id)
               :style {:margin-left (str (* depth 1) "rem")}
               :class (into ["hover:text-primary" :transition-300] (if (= depth 0)

--- a/src/repliweb/article.clj
+++ b/src/repliweb/article.clj
@@ -121,7 +121,7 @@
   "Render table of contents component"
   [toc-entries]
   (when (seq toc-entries)
-    [:div.text-sm.leading-6.overflow-y-auto.space-y-2.pb-4.-mt-10.pt-10.text-base-content#table-of-contents {:class ["text-base-content" "w-[19rem]"]}
+    [:div.text-sm.leading-6.overflow-y-auto.space-y-2.pb-4.-mt-10.pt-10.text-base-content#table-of-contents {:class ["w-[19rem]"]}
      [:div.font-medium.flex.items-center.space-x-2
       (render-toc-icon)
       [:span "On this page"]]

--- a/src/repliweb/article.clj
+++ b/src/repliweb/article.clj
@@ -77,8 +77,7 @@
               :text title
               :depth (case level 2 0 3 1)})))))
 
-(defn md->toc
-  [md]
+(defn md->toc [md]
   (when (not-empty md)
     (let [lines (str/split-lines md)
           heading-pattern #"^(#{2,3})\s+(.+)$"]
@@ -103,8 +102,7 @@
                         {:id id :text text :depth depth})))))
            (filter some?)))))
 
-(defn page->toc
-  [page]
+(defn page->toc [page]
   (let [blocks-toc (blocks->toc (:page/blocks page))
         markdown-toc (md->toc (:page/body page))]
     (->> (concat blocks-toc markdown-toc)
@@ -112,8 +110,7 @@
 
 ;; Couldn't find this icon as part of phosphor and I think it fits better than a
 ;; normal menu icon.
-(defn render-toc-icon
-  []
+(defn render-toc-icon []
   [:svg.h-3.w-3 {:width "16" :height "16" :viewBox "0 0 16 16" :fill "none"
                              :stroke "currentColor" :stroke-width "2" :xmlns "http://www.w3.org/2000/svg"}
    [:path {:d "M2.44434 12.6665H13.5554" :stroke-linecap "round" :stroke-linejoin "round"}]
@@ -124,14 +121,13 @@
   "Render table of contents component"
   [toc-entries]
   (when (seq toc-entries)
-    [:div.text-sm.leading-6.overflow-y-auto.space-y-2.pb-4.-mt-10.pt-10 {:id :table-of-contents
-                                                                         :class ["text-base-content" "w-[19rem]"]}
+    [:div.text-sm.leading-6.overflow-y-auto.space-y-2.pb-4.-mt-10.pt-10.text-base-content#table-of-contents {:class ["text-base-content" "w-[19rem]"]}
      [:div.font-medium.flex.items-center.space-x-2
       (render-toc-icon)
       [:span "On this page"]]
-     [:ul.toc {:id :table-of-contents-content}
+     [:ul#table-of-contents-content
       (for [{:keys [id text depth]} toc-entries]
-        [:li.toc-item.relative {:key id :data-depth depth}
+        [:li.relative {:data-depth depth}
          [:a {:href (str "#" id)
               :style {:margin-left (str (* depth 1) "rem")}
               :class (into ["hover:text-primary" :transition-300] (if (= depth 0)

--- a/src/repliweb/assets.clj
+++ b/src/repliweb/assets.clj
@@ -18,8 +18,8 @@
 
                      "/app.js"
                      {:public-dir "public"
-                      :paths ["/js/compiled/app.js"]}
-                     }
+                      :paths ["/js/compiled/app.js"
+                              "/js/toc.js"]}}
 
    :optimus/assets [{:public-dir "public"
                      :paths [#"\.png$"


### PR DESCRIPTION
This PR adds interactive ToC to articles.

The mechanism extracts ToC from both blocks and normal `:page/body`.

The interactivity mechanism: 
- Try to get elements by id of the toc anchor (blocks have the id set when rendered as html) 
- Try to get h2 or h3 elements with the same text as the ToC element

![CleanShot 2025-09-26 at 08 45 30](https://github.com/user-attachments/assets/796741f0-23f6-445b-9ac2-b87c8ae6284b)


Small issue when the last element doesn't take sufficient space, the last toc won't be highlighted. In practice, I don't think it influences that much, as most articles have some text for the last section, so this is not impacted, but this is visible for articles with the last part being a small conclusion let's say. 
<img width="1321" height="870" alt="image" src="https://github.com/user-attachments/assets/435e9a06-a761-47b5-a341-2926418d107d" />

To fix this you would need to fiddle with the offset from top at which you consider the element is active (currently this is 80px)