### PR TITLE
Inherit text color in popover

### DIFF
--- a/src/repliweb/article.clj
+++ b/src/repliweb/article.clj
@@ -148,7 +148,7 @@
       [:div.p-4.bg-base-200.items-center.flex.flex-row.gap-4.sticky.top-0.z-10
        [:button {:popovertarget "menu"}
         (icons/render :phosphor.regular/list {:size 24})]
-       [:div.bg-base-200.m-0.px-0.absolute.h-full {:popover "auto" :id "menu"}
+       [:div.bg-base-200.m-0.px-0.absolute.h-full.text-inherit {:popover "auto" :id "menu"}
         (menu db page)]
        (page-kind->text (:page/kind page)) ": " (:page/title page)]
       [:div.md:flex.relative


### PR DESCRIPTION
By default, browsers will apply `color: canvastext` to content in a popover. For the replicant docs site, this makes all text in the sidebar appear as white, which makes it hard to see which lines are headings and which are clickable.

By adding `color: inherit`, here done with the tailwind style `text-inherit`, we preserve the intended colors inside the popover.

<details>
<summary>Expand to see comparison screenshots</summary>

### Before
<img width="540" height="1810" alt="image" src="https://github.com/user-attachments/assets/a1fe45a0-7483-4f9e-9f89-bffe5cf34d4e" />

### After
<img width="540" height="1810" alt="image" src="https://github.com/user-attachments/assets/751544d2-7371-4679-aa4f-bb8ca9be33ba" />

</details>
