### PR TITLE
Add missing function examples to tic-tac-toe and routing tutorial

### DIFF
--- a/content/routing.md
+++ b/content/routing.md
@@ -265,9 +265,15 @@ when code is hot reloaded):
   (main el state))
 ```
 
-To test our new capability we will add a render function for the episode page:
+To test our new capability we will add a render function for the episode page.
+We'll also need a utility function to get the data for an episode given its ID:
 
 ```clj
+(defn get-episode [{:keys [videos]} {:keys [location/params]}]
+  (->> videos
+       (filter (comp #{(:episode/id params)} :episode/id))
+       first))
+
 (defn render-episode [state location]
   [:main
    (if-let [episode (get-episode state location)]

--- a/content/tic-tac-toe.md
+++ b/content/tic-tac-toe.md
@@ -629,7 +629,19 @@ For our next test, let's place a tic for player x:
 ```
 
 Since the game already knows whose turn it is, we don't need to pass it
-explicitly. Next, we'll place another mark:
+explicitly:
+
+```clj
+(def next-player {:x :o, :o :x})
+
+(defn tic [game y x]
+  (let [player (:next-player game)]
+    (-> game
+        (assoc-in [:tics [y x]] player)
+        (assoc game :next-player (next-player player)))))
+```
+
+Next, we'll test placing another mark:
 
 ```clj
 (testing "O places a tic"
@@ -659,8 +671,6 @@ This test fails because our current implementation allows the o player overwrite
 the x. Not good, let's fix it:
 
 ```clj
-(def next-player {:x :o, :o :x})
-
 (defn tic [game y x]
   (let [player (:next-player game)]
     (if (get-in game [:tics [y x]])


### PR DESCRIPTION
I'm currently working my way through the tutorials and noticed some example from the reference repositories were missing from the instructional text.

Thank you for all of the effort that went into not only replicant, but the great documentation as well :)